### PR TITLE
support explicit event type on event controllers

### DIFF
--- a/ezyfox-server-core/src/main/java/com/tvd12/ezyfoxserver/controller/EzyEventController.java
+++ b/ezyfox-server-core/src/main/java/com/tvd12/ezyfoxserver/controller/EzyEventController.java
@@ -1,6 +1,12 @@
 package com.tvd12.ezyfoxserver.controller;
 
+import com.tvd12.ezyfox.constant.EzyConstant;
+
 public interface EzyEventController<C, E> {
 
     void handle(C ctx, E event);
+
+    default EzyConstant getEventType() {
+        return null;
+    }
 }

--- a/ezyfox-server-support/src/main/java/com/tvd12/ezyfoxserver/support/entry/EzySimpleAppEntry.java
+++ b/ezyfox-server-support/src/main/java/com/tvd12/ezyfoxserver/support/entry/EzySimpleAppEntry.java
@@ -5,6 +5,7 @@ import com.tvd12.ezyfox.bean.EzyBeanContextBuilder;
 import com.tvd12.ezyfox.binding.EzyBindingContext;
 import com.tvd12.ezyfox.binding.EzyMarshaller;
 import com.tvd12.ezyfox.binding.EzyUnmarshaller;
+import com.tvd12.ezyfox.constant.EzyConstant;
 import com.tvd12.ezyfox.core.annotation.EzyEventHandler;
 import com.tvd12.ezyfox.core.annotation.EzyExceptionHandler;
 import com.tvd12.ezyfox.core.annotation.EzyRequestController;
@@ -63,11 +64,16 @@ public class EzySimpleAppEntry extends EzyAbstractAppEntry {
         List<Object> eventControllers = beanContext.getSingletons(EzyEventHandler.class);
         sortEventHandlersByPriority(eventControllers);
         for (Object controller : eventControllers) {
-            Class<?> controllerType = controller.getClass();
-            EzyEventHandler annotation = controllerType.getAnnotation(EzyEventHandler.class);
-            String eventName = EzyEventHandlerAnnotations.getEvent(annotation);
-            setup.addEventController(EzyEventType.valueOf(eventName), (EzyEventController) controller);
-            logger.info("add  event {} controller {}", eventName, controller);
+            EzyEventController eventController = (EzyEventController) controller;
+            EzyConstant eventType = eventController.getEventType();
+            if (eventType == null) {
+                Class<?> controllerType = controller.getClass();
+                EzyEventHandler annotation = controllerType.getAnnotation(EzyEventHandler.class);
+                String eventName = EzyEventHandlerAnnotations.getEvent(annotation);
+                eventType = EzyEventType.valueOf(eventName);
+            }
+            setup.addEventController(eventType, eventController);
+            logger.info("add event {} controller {}", eventType, controller);
         }
     }
 

--- a/ezyfox-server-support/src/main/java/com/tvd12/ezyfoxserver/support/entry/EzySimplePluginEntry.java
+++ b/ezyfox-server-support/src/main/java/com/tvd12/ezyfoxserver/support/entry/EzySimplePluginEntry.java
@@ -5,6 +5,7 @@ import com.tvd12.ezyfox.bean.EzyBeanContextBuilder;
 import com.tvd12.ezyfox.binding.EzyBindingContext;
 import com.tvd12.ezyfox.binding.EzyMarshaller;
 import com.tvd12.ezyfox.binding.EzyUnmarshaller;
+import com.tvd12.ezyfox.constant.EzyConstant;
 import com.tvd12.ezyfox.core.annotation.EzyEventHandler;
 import com.tvd12.ezyfox.core.annotation.EzyExceptionHandler;
 import com.tvd12.ezyfox.core.annotation.EzyRequestController;
@@ -64,11 +65,16 @@ public class EzySimplePluginEntry extends EzyAbstractPluginEntry {
         List<Object> eventControllers = beanContext.getSingletons(EzyEventHandler.class);
         sortEventHandlersByPriority(eventControllers);
         for (Object controller : eventControllers) {
-            Class<?> handlerType = controller.getClass();
-            EzyEventHandler annotation = handlerType.getAnnotation(EzyEventHandler.class);
-            String eventName = EzyEventHandlerAnnotations.getEvent(annotation);
-            setup.addEventController(EzyEventType.valueOf(eventName), (EzyEventController) controller);
-            logger.info("add  event {} controller {}", eventName, controller);
+            EzyEventController eventController = (EzyEventController) controller;
+            EzyConstant eventType = eventController.getEventType();
+            if (eventType == null) {
+                Class<?> handlerType = controller.getClass();
+                EzyEventHandler annotation = handlerType.getAnnotation(EzyEventHandler.class);
+                String eventName = EzyEventHandlerAnnotations.getEvent(annotation);
+                eventType = EzyEventType.valueOf(eventName);
+            }
+            setup.addEventController(eventType, eventController);
+            logger.info("add event {} controller {}", eventType, controller);
         }
     }
 

--- a/ezyfox-server-support/src/test/java/com/tvd12/ezyfoxserver/support/test/entry/EzySimpleAppEntryTest.java
+++ b/ezyfox-server-support/src/test/java/com/tvd12/ezyfoxserver/support/test/entry/EzySimpleAppEntryTest.java
@@ -1,13 +1,17 @@
 package com.tvd12.ezyfoxserver.support.test.entry;
 
+import com.tvd12.ezyfox.bean.EzyBeanContext;
 import com.tvd12.ezyfox.bean.EzyBeanContextBuilder;
 import com.tvd12.ezyfox.concurrent.EzyErrorScheduledExecutorService;
+import com.tvd12.ezyfox.constant.EzyConstant;
+import com.tvd12.ezyfox.core.annotation.EzyEventHandler;
 import com.tvd12.ezyfox.entity.EzyArray;
 import com.tvd12.ezyfox.factory.EzyEntityFactory;
 import com.tvd12.ezyfoxserver.EzySimpleApplication;
 import com.tvd12.ezyfoxserver.EzySimpleServer;
 import com.tvd12.ezyfoxserver.EzySimpleZone;
 import com.tvd12.ezyfoxserver.app.EzyAppRequestController;
+import com.tvd12.ezyfoxserver.constant.EzyEventNames;
 import com.tvd12.ezyfoxserver.constant.EzyEventType;
 import com.tvd12.ezyfoxserver.context.EzyAppContext;
 import com.tvd12.ezyfoxserver.context.EzySimpleAppContext;
@@ -17,8 +21,10 @@ import com.tvd12.ezyfoxserver.controller.EzyEventController;
 import com.tvd12.ezyfoxserver.entity.EzyAbstractSession;
 import com.tvd12.ezyfoxserver.entity.EzySimpleUser;
 import com.tvd12.ezyfoxserver.event.EzySimpleUserRequestAppEvent;
+import com.tvd12.ezyfoxserver.event.EzyUserLoginEvent;
 import com.tvd12.ezyfoxserver.event.EzyUserRequestAppEvent;
 import com.tvd12.ezyfoxserver.setting.*;
+import com.tvd12.ezyfoxserver.support.controller.EzyCommandsAware;
 import com.tvd12.ezyfoxserver.support.entry.EzySimpleAppEntry;
 import com.tvd12.ezyfoxserver.wrapper.EzyAppUserManager;
 import com.tvd12.ezyfoxserver.wrapper.EzyEventControllers;
@@ -27,10 +33,12 @@ import com.tvd12.ezyfoxserver.wrapper.impl.EzyEventControllersImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.*;
 
 public class EzySimpleAppEntryTest {
 
@@ -217,6 +225,59 @@ public class EzySimpleAppEntryTest {
         entry.destroy();
     }
 
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void explicitEventTypeTest() throws Exception {
+        // given
+        EzySimpleSettings settings = new EzySimpleSettings();
+        EzySimpleServer server = new EzySimpleServer();
+        server.setSettings(settings);
+        EzySimpleServerContext serverContext = new EzySimpleServerContext();
+        serverContext.setServer(server);
+        serverContext.init();
+
+        EzySimpleZoneSetting zoneSetting = new EzySimpleZoneSetting();
+        EzySimpleZone zone = new EzySimpleZone();
+        zone.setSetting(zoneSetting);
+        EzySimpleZoneContext zoneContext = new EzySimpleZoneContext();
+        zoneContext.setZone(zone);
+        zoneContext.init();
+        zoneContext.setParent(serverContext);
+
+        EzySimpleAppSetting appSetting = new EzySimpleAppSetting();
+        appSetting.setName("test");
+
+        EzyAppUserManager appUserManager = EzyAppUserManagerImpl.builder()
+            .build();
+
+        EzyEventControllersSetting eventControllersSetting = new EzySimpleEventControllersSetting();
+        EzyEventControllers eventControllers = EzyEventControllersImpl.create(eventControllersSetting);
+        EzySimpleApplication application = new EzySimpleApplication();
+        application.setSetting(appSetting);
+        application.setUserManager(appUserManager);
+        application.setEventControllers(eventControllers);
+
+        ScheduledExecutorService appScheduledExecutorService = new EzyErrorScheduledExecutorService("not implement");
+        EzySimpleAppContext appContext = new EzySimpleAppContext();
+        appContext.setApp(application);
+        appContext.setParent(zoneContext);
+        appContext.setExecutorService(appScheduledExecutorService);
+        appContext.init();
+
+        EzySimpleAppEntry entry = new EventTypeAwareAppEntry();
+
+        // when
+        entry.config(appContext);
+
+        // then
+        List<EzyEventController> userLoginHandlers = appContext
+            .getApp()
+            .getEventControllers()
+            .getControllers(EzyEventType.USER_LOGIN);
+        Assert.assertEquals(userLoginHandlers.size(), 1);
+        Assert.assertEquals(userLoginHandlers.get(0).getClass(), EventTypeAwareUserLoginHandler.class);
+    }
+
     public static class EzyAppEntryEx extends EzySimpleAppEntry {
 
         @Override
@@ -249,5 +310,45 @@ public class EzySimpleAppEntryTest {
 
         @Override
         protected void setupBeanContext(EzyAppContext context, EzyBeanContextBuilder builder) {}
+    }
+
+    public static class EventTypeAwareAppEntry extends EzySimpleAppEntry {
+
+        @Override
+        protected EzyBeanContext createBeanContext(EzyAppContext context) {
+            EzyBeanContext beanContext = mock(EzyBeanContext.class);
+            when(beanContext.getSingletons(EzyEventHandler.class))
+                .thenReturn(Collections.singletonList(new EventTypeAwareUserLoginHandler()));
+            return beanContext;
+        }
+
+        @Override
+        protected EzyAppRequestController newUserRequestController(EzyBeanContext beanContext) {
+            return new NoOpRequestController();
+        }
+    }
+
+    @EzyEventHandler(EzyEventNames.USER_LOGIN)
+    public static class EventTypeAwareUserLoginHandler
+        implements EzyEventController<EzyAppContext, EzyUserLoginEvent> {
+
+        public EzyConstant getEventType() {
+            return EzyEventType.USER_LOGIN;
+        }
+
+        @Override
+        public void handle(EzyAppContext ctx, EzyUserLoginEvent event) {}
+    }
+
+    public static class NoOpRequestController
+        implements EzyAppRequestController, EzyCommandsAware {
+
+        @Override
+        public Set<String> getCommands() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void handle(EzyAppContext ctx, EzyUserRequestAppEvent event) {}
     }
 }

--- a/ezyfox-server-support/src/test/java/com/tvd12/ezyfoxserver/support/test/entry/EzySimplePluginEntryTest.java
+++ b/ezyfox-server-support/src/test/java/com/tvd12/ezyfoxserver/support/test/entry/EzySimplePluginEntryTest.java
@@ -2,11 +2,14 @@ package com.tvd12.ezyfoxserver.support.test.entry;
 
 import com.tvd12.ezyfox.bean.EzyBeanContextBuilder;
 import com.tvd12.ezyfox.concurrent.EzyErrorScheduledExecutorService;
+import com.tvd12.ezyfox.constant.EzyConstant;
+import com.tvd12.ezyfox.core.annotation.EzyEventHandler;
 import com.tvd12.ezyfox.entity.EzyArray;
 import com.tvd12.ezyfox.factory.EzyEntityFactory;
 import com.tvd12.ezyfoxserver.EzySimplePlugin;
 import com.tvd12.ezyfoxserver.EzySimpleServer;
 import com.tvd12.ezyfoxserver.EzySimpleZone;
+import com.tvd12.ezyfoxserver.constant.EzyEventNames;
 import com.tvd12.ezyfoxserver.constant.EzyEventType;
 import com.tvd12.ezyfoxserver.context.EzyPluginContext;
 import com.tvd12.ezyfoxserver.context.EzySimplePluginContext;
@@ -16,6 +19,7 @@ import com.tvd12.ezyfoxserver.controller.EzyEventController;
 import com.tvd12.ezyfoxserver.entity.EzyAbstractSession;
 import com.tvd12.ezyfoxserver.entity.EzySimpleUser;
 import com.tvd12.ezyfoxserver.event.EzySimpleUserRequestPluginEvent;
+import com.tvd12.ezyfoxserver.event.EzyUserLoginEvent;
 import com.tvd12.ezyfoxserver.event.EzyUserRequestPluginEvent;
 import com.tvd12.ezyfoxserver.plugin.EzyPluginRequestController;
 import com.tvd12.ezyfoxserver.setting.*;
@@ -198,6 +202,55 @@ public class EzySimplePluginEntryTest {
         entry.destroy();
     }
 
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void explicitEventTypeTest() throws Exception {
+        // given
+        EzySimpleSettings settings = new EzySimpleSettings();
+        EzySimpleServer server = new EzySimpleServer();
+        server.setSettings(settings);
+        EzySimpleServerContext serverContext = new EzySimpleServerContext();
+        serverContext.setServer(server);
+        serverContext.init();
+
+        EzySimpleZoneSetting zoneSetting = new EzySimpleZoneSetting();
+        EzySimpleZone zone = new EzySimpleZone();
+        zone.setSetting(zoneSetting);
+        EzySimpleZoneContext zoneContext = new EzySimpleZoneContext();
+        zoneContext.setZone(zone);
+        zoneContext.init();
+        zoneContext.setParent(serverContext);
+
+        EzySimplePluginSetting pluginSetting = new EzySimplePluginSetting();
+        pluginSetting.setName("test");
+
+        EzyEventControllersSetting eventControllersSetting = new EzySimpleEventControllersSetting();
+        EzyEventControllers eventControllers = EzyEventControllersImpl.create(eventControllersSetting);
+        EzySimplePlugin plugin = new EzySimplePlugin();
+        plugin.setSetting(pluginSetting);
+        plugin.setEventControllers(eventControllers);
+
+        ScheduledExecutorService pluginScheduledExecutorService = new EzyErrorScheduledExecutorService("not implement");
+        EzySimplePluginContext pluginContext = new EzySimplePluginContext();
+        pluginContext.setPlugin(plugin);
+        pluginContext.setParent(zoneContext);
+        pluginContext.setExecutorService(pluginScheduledExecutorService);
+        pluginContext.init();
+
+        EzySimplePluginEntry entry = new EventTypeAwarePluginEntry();
+
+        // when
+        entry.config(pluginContext);
+
+        // then
+        List<EzyEventController> userLoginHandlers = pluginContext
+            .getPlugin()
+            .getEventControllers()
+            .getControllers(EzyEventType.USER_LOGIN);
+        Assert.assertEquals(userLoginHandlers.size(), 1);
+        Assert.assertEquals(userLoginHandlers.get(0).getClass(), EventTypeAwareUserLoginHandler.class);
+    }
+
     public static class EzyPluginEntryEx extends EzySimplePluginEntry {
 
         @Override
@@ -230,5 +283,30 @@ public class EzySimplePluginEntryTest {
 
         @Override
         protected void setupBeanContext(EzyPluginContext context, EzyBeanContextBuilder builder) {}
+    }
+
+    public static class EventTypeAwarePluginEntry extends EzySimplePluginEntry {
+
+        @Override
+        protected boolean allowRequest() {
+            return false;
+        }
+
+        @Override
+        protected void setupBeanContext(EzyPluginContext context, EzyBeanContextBuilder builder) {
+            builder.addSingleton(new EventTypeAwareUserLoginHandler());
+        }
+    }
+
+    @EzyEventHandler(EzyEventNames.USER_LOGIN)
+    private static class EventTypeAwareUserLoginHandler
+        implements EzyEventController<EzyPluginContext, EzyUserLoginEvent> {
+
+        public EzyConstant getEventType() {
+            return EzyEventType.USER_LOGIN;
+        }
+
+        @Override
+        public void handle(EzyPluginContext ctx, EzyUserLoginEvent event) {}
     }
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

Add a default `getEventType()` hook to `EzyEventController` and use it when registering app and plugin event controllers. Fall back to the `@EzyEventHandler` annotation when controllers do not provide an explicit event type.

Add app and plugin entry tests for controllers that return a non-null event type.

### When do you want to merge?
ASAP