### PR TITLE
ci: add advisory Arcade architecture analysis

### DIFF
--- a/.github/workflows/arcade-architecture-analysis.yml
+++ b/.github/workflows/arcade-architecture-analysis.yml
@@ -1,0 +1,28 @@
+name: Arcade Architecture Analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  analyze:
+    name: Architecture advisory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lemduc/arcade-agent/actions/analyze@v0.1.1
+        with:
+          arcade-agent-version: "0.1.1"
+          language: java
+          primary-algorithm: pkg
+          run-secondary-analyses: "false"
+          upload-artifacts: "true"
+          post-pr-comment: "true"


### PR DESCRIPTION
## What changed

- add one advisory Arcade architecture analysis workflow for pull requests, `master` pushes, and manual runs
- pin both the composite action and installed package to released version `v0.1.1`
- analyze Java with the package-based recovery algorithm, upload the report, and store a default-branch baseline
- keep secondary analyses disabled to reduce CI time and update one idempotent PR summary when write access is available

## Why

This gives reviewers architecture-level dependency context without changing the Maven build or introducing a merge threshold. The report is intended as supporting evidence for human review.

The `issues: write` and `pull-requests: write` permissions are used only for the idempotent analysis comment. The action skips comments for forked pull requests, where GitHub does not grant a write token.

## Impact

This is a one-file CI-only proposal. It does not modify production code or existing code style.

## Validation

- `actionlint` passed for the workflow
- released `arcade-agent[languages]==0.1.1` completed a local Java/package baseline against `a845cd96a3d6`
- baseline recovered 2,899 entities, 9,964 dependency edges, and 59 components

The detailed baseline interpretation is included in a separate PR comment.
